### PR TITLE
Allow host I/O to be used for serial port

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/maxfierke/gogo-gb/cart"
 	"github.com/maxfierke/gogo-gb/cart/mbc"
@@ -66,7 +68,7 @@ func init() {
 
 	runCmd.Flags().StringVarP(&runCmdOptions.debugger, "debugger", "d", "", "Specify debugger to use (\"gameboy-doctor\", \"interactive\")")
 	runCmd.Flags().StringVarP(&runCmdOptions.model, "model", "m", "auto", "Specify model to use (\"auto\", \"dmg\", \"cgb\")")
-	runCmd.Flags().StringVarP(&runCmdOptions.serialPort, "serial-port", "p", "", "Path to serial port IO (could be a file, UNIX socket, etc.)")
+	runCmd.Flags().StringVarP(&runCmdOptions.serialPort, "serial-port", "p", "", "Path to serial port IO (named pipe or unix socket)")
 	runCmd.Flags().BoolVar(&runCmdOptions.skipBootRom, "skip-bootrom", false, "Skip loading a boot ROM")
 	runCmd.Flags().BoolVar(&runCmdOptions.headless, "headless", false, "Launch without UI")
 }
@@ -129,13 +131,59 @@ func initHost(logger *log.Logger, options *RunCmdOptions) (host.Host, error) {
 		case "stderr", "/dev/stderr":
 			serialCable.SetWriter(os.Stderr)
 		default:
-			serialPort, err := os.Create(options.serialPort)
-			if err != nil {
-				return nil, fmt.Errorf("unable to open file '%s' as serial port: %w", options.serialPort, err)
-			}
+			if strings.HasSuffix(options.serialPort, ".sock") {
+				if info, _ := os.Stat(options.serialPort); info.Mode().Type() == os.ModeSocket {
+					if err := os.Remove(options.serialPort); err != nil {
+						return nil, fmt.Errorf("unable to remove existing unix socket '%s': %w", options.serialPort, err)
+					}
+				}
 
-			serialCable.SetReader(serialPort)
-			serialCable.SetWriter(serialPort)
+				listener, err := net.Listen("unix", options.serialPort)
+				if err != nil {
+					return nil, fmt.Errorf("unable to open unix socket '%s' as serial port: %w", options.serialPort, err)
+				}
+
+				go func() {
+					defer os.RemoveAll(options.serialPort)
+
+					for {
+						conn, err := listener.Accept()
+						if err != nil {
+							logger.Printf("ERROR: unable to accept connections to serial port domain socket: %v", err)
+
+							return
+						}
+						defer conn.Close()
+
+						serialCable.SetReader(conn)
+						serialCable.SetWriter(conn)
+					}
+				}()
+			} else {
+				info, err := os.Stat(options.serialPort)
+				if err != nil {
+					if errors.Is(err, os.ErrNotExist) {
+						err := syscall.Mkfifo(options.serialPort, 0o664)
+						if err != nil {
+							return nil, fmt.Errorf("creating named pipe at '%s': %w", options.serialPort, err)
+						}
+					} else {
+						return nil, fmt.Errorf("unable to open file '%s' as serial port: %w", options.serialPort, err)
+					}
+				}
+
+				if info.Mode().Type() != os.ModeNamedPipe {
+					return nil, fmt.Errorf("unable to open file '%s' as serial port: not a named pipe or unix socket", options.serialPort)
+				}
+
+				serialPort, err := os.OpenFile(options.serialPort, os.O_RDWR|os.O_TRUNC|syscall.O_NONBLOCK, 0o664)
+				if err != nil {
+					return nil, fmt.Errorf("opening file '%s' as serial port: %w", options.serialPort, err)
+				}
+
+				serialCable.SetReader(serialPort)
+				serialCable.SetWriter(serialPort)
+			}
 		}
 
 		hostDevice.AttachSerialCable(serialCable)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -8,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/maxfierke/gogo-gb/cart"
 	"github.com/maxfierke/gogo-gb/cart/mbc"
@@ -45,11 +45,13 @@ Options can be specified to attach a debugger, control peripherals, and specify 
 			return fmt.Errorf("getting logger: %w", err)
 		}
 
+		ctx := context.Background()
+
 		cartPath := args[0]
 		runCmdOptions.cartPath = cartPath
 
 		logger.Println("welcome to gogo-gb, the go-getting GB emulator")
-		if err := runCart(logger, &runCmdOptions); err != nil {
+		if err := runCart(ctx, logger, &runCmdOptions); err != nil {
 			return err
 		}
 
@@ -68,7 +70,7 @@ func init() {
 
 	runCmd.Flags().StringVarP(&runCmdOptions.debugger, "debugger", "d", "", "Specify debugger to use (\"gameboy-doctor\", \"interactive\")")
 	runCmd.Flags().StringVarP(&runCmdOptions.model, "model", "m", "auto", "Specify model to use (\"auto\", \"dmg\", \"cgb\")")
-	runCmd.Flags().StringVarP(&runCmdOptions.serialPort, "serial-port", "p", "", "Path to serial port IO (named pipe or unix socket)")
+	runCmd.Flags().StringVarP(&runCmdOptions.serialPort, "serial-port", "p", "", "Path to serial port IO (unix domain socket)")
 	runCmd.Flags().BoolVar(&runCmdOptions.skipBootRom, "skip-bootrom", false, "Skip loading a boot ROM")
 	runCmd.Flags().BoolVar(&runCmdOptions.headless, "headless", false, "Launch without UI")
 }
@@ -111,7 +113,7 @@ func getCartSaveFilePath(options *RunCmdOptions) string {
 	return cartSaveFilePath
 }
 
-func initHost(logger *log.Logger, options *RunCmdOptions) (host.Host, error) {
+func initHost(ctx context.Context, logger *log.Logger, options *RunCmdOptions) (host.Host, error) {
 	var hostDevice host.Host
 
 	if options.headless {
@@ -127,63 +129,41 @@ func initHost(logger *log.Logger, options *RunCmdOptions) (host.Host, error) {
 
 		switch options.serialPort {
 		case "stdout", "/dev/stdout":
-			serialCable.SetWriter(os.Stdout)
+			serialCable.SetWriter(ctx, os.Stdout)
 		case "stderr", "/dev/stderr":
-			serialCable.SetWriter(os.Stderr)
+			serialCable.SetWriter(ctx, os.Stderr)
 		default:
-			if strings.HasSuffix(options.serialPort, ".sock") {
-				if info, _ := os.Stat(options.serialPort); info.Mode().Type() == os.ModeSocket {
-					if err := os.Remove(options.serialPort); err != nil {
-						return nil, fmt.Errorf("unable to remove existing unix socket '%s': %w", options.serialPort, err)
-					}
+			if info, _ := os.Stat(options.serialPort); info.Mode().Type() == os.ModeSocket {
+				if err := os.Remove(options.serialPort); err != nil {
+					return nil, fmt.Errorf("unable to remove existing unix socket '%s': %w", options.serialPort, err)
 				}
-
-				listener, err := net.Listen("unix", options.serialPort)
-				if err != nil {
-					return nil, fmt.Errorf("unable to open unix socket '%s' as serial port: %w", options.serialPort, err)
-				}
-
-				go func() {
-					defer os.RemoveAll(options.serialPort)
-
-					for {
-						conn, err := listener.Accept()
-						if err != nil {
-							logger.Printf("ERROR: unable to accept connections to serial port domain socket: %v", err)
-
-							return
-						}
-						defer conn.Close()
-
-						serialCable.SetReader(conn)
-						serialCable.SetWriter(conn)
-					}
-				}()
-			} else {
-				info, err := os.Stat(options.serialPort)
-				if err != nil {
-					if errors.Is(err, os.ErrNotExist) {
-						err := syscall.Mkfifo(options.serialPort, 0o664)
-						if err != nil {
-							return nil, fmt.Errorf("creating named pipe at '%s': %w", options.serialPort, err)
-						}
-					} else {
-						return nil, fmt.Errorf("unable to open file '%s' as serial port: %w", options.serialPort, err)
-					}
-				}
-
-				if info.Mode().Type() != os.ModeNamedPipe {
-					return nil, fmt.Errorf("unable to open file '%s' as serial port: not a named pipe or unix socket", options.serialPort)
-				}
-
-				serialPort, err := os.OpenFile(options.serialPort, os.O_RDWR|os.O_TRUNC|syscall.O_NONBLOCK, 0o664)
-				if err != nil {
-					return nil, fmt.Errorf("opening file '%s' as serial port: %w", options.serialPort, err)
-				}
-
-				serialCable.SetReader(serialPort)
-				serialCable.SetWriter(serialPort)
 			}
+
+			listener, err := net.Listen("unix", options.serialPort)
+			if err != nil {
+				return nil, fmt.Errorf("unable to open unix socket '%s' as serial port: %w", options.serialPort, err)
+			}
+
+			go func() {
+				defer os.RemoveAll(options.serialPort)
+
+				for {
+					if ctx.Err() != nil {
+						return
+					}
+
+					conn, err := listener.Accept()
+					if err != nil {
+						logger.Printf("ERROR: unable to accept connections to serial port domain socket: %v", err)
+
+						return
+					}
+					defer conn.Close()
+
+					serialCable.SetReader(ctx, conn)
+					serialCable.SetWriter(ctx, conn)
+				}
+			}()
 		}
 
 		hostDevice.AttachSerialCable(serialCable)
@@ -328,7 +308,7 @@ func loadCartSave(console hardware.Console, logger *log.Logger, options *RunCmdO
 			}
 		}
 
-		logger.Printf("Loaded cartridge save from %s\n", cartSaveFilePath)
+		logger.Printf("loaded cartridge save from %s\n", cartSaveFilePath)
 	}
 
 	return nil
@@ -353,8 +333,8 @@ func saveCart(console hardware.Console, logger *log.Logger, options *RunCmdOptio
 	return nil
 }
 
-func runCart(logger *log.Logger, options *RunCmdOptions) error {
-	consoleHost, err := initHost(logger, options)
+func runCart(ctx context.Context, logger *log.Logger, options *RunCmdOptions) error {
+	consoleHost, err := initHost(ctx, logger, options)
 	if err != nil {
 		return fmt.Errorf("unable to initialize host device: %w", err)
 	}

--- a/devices/serial_cable.go
+++ b/devices/serial_cable.go
@@ -2,8 +2,12 @@ package devices
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"io"
 )
+
+var ErrChangingReaderWriter = errors.New("changing reader/writer")
 
 type SerialCable interface {
 	io.ByteReader
@@ -21,37 +25,93 @@ func (sc *NullSerialCable) WriteByte(value byte) error {
 }
 
 type HostSerialCable struct {
-	reader io.Reader
-	writer io.Writer
+	rxChan   chan byte
+	rxCancel context.CancelCauseFunc
+
+	txChan   chan byte
+	txCancel context.CancelCauseFunc
 }
 
 func NewHostSerialCable() *HostSerialCable {
-	return &HostSerialCable{
-		reader: bytes.NewReader([]byte{}),
-		writer: io.Discard,
+	sc := &HostSerialCable{
+		rxChan: make(chan byte),
+		txChan: make(chan byte),
 	}
+
+	ctx := context.Background()
+	sc.SetReader(ctx, bytes.NewReader([]byte{}))
+	sc.SetWriter(ctx, io.Discard)
+
+	return sc
 }
 
 func (sc *HostSerialCable) ReadByte() (byte, error) {
-	readBuf := []byte{0x00}
-
-	if _, err := sc.reader.Read(readBuf); err != nil {
-		return 0xFF, err
+	select {
+	case value := <-sc.rxChan:
+		return value, nil
+	default:
+		return 0xFF, errors.New("read channel empty")
 	}
-
-	return readBuf[0], nil
 }
 
 func (sc *HostSerialCable) WriteByte(value byte) error {
-	_, err := sc.writer.Write([]byte{value})
+	select {
+	case sc.txChan <- value:
+	default:
+		return errors.New("write channel full")
+	}
 
-	return err
+	return nil
 }
 
-func (sc *HostSerialCable) SetReader(reader io.Reader) {
-	sc.reader = reader
+func (sc *HostSerialCable) SetReader(ctx context.Context, reader io.Reader) {
+	if sc.rxCancel != nil {
+		sc.rxCancel(ErrChangingReaderWriter)
+	}
+	ctx, cancel := context.WithCancelCause(ctx)
+	sc.rxCancel = cancel
+	go sc.receivePoll(ctx, reader)
 }
 
-func (sc *HostSerialCable) SetWriter(writer io.Writer) {
-	sc.writer = writer
+func (sc *HostSerialCable) SetWriter(ctx context.Context, writer io.Writer) {
+	if sc.txCancel != nil {
+		sc.txCancel(ErrChangingReaderWriter)
+	}
+	ctx, cancel := context.WithCancelCause(ctx)
+	sc.txCancel = cancel
+	go sc.writePoll(ctx, writer)
+}
+
+func (sc *HostSerialCable) receivePoll(ctx context.Context, reader io.Reader) {
+	var readBuf [1]byte
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		if n, err := reader.Read(readBuf[:]); err != nil && err != io.EOF {
+			return
+		} else if n > 0 {
+			select {
+			case sc.rxChan <- readBuf[0]:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+func (sc *HostSerialCable) writePoll(ctx context.Context, writer io.Writer) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		select {
+		case value := <-sc.txChan:
+			_, _ = writer.Write([]byte{value})
+		case <-ctx.Done():
+			return
+		}
+	}
 }

--- a/devices/serial_cable.go
+++ b/devices/serial_cable.go
@@ -6,8 +6,8 @@ import (
 )
 
 type SerialCable interface {
-	ReadByte() (byte, error)
-	WriteByte(value byte) error
+	io.ByteReader
+	io.ByteWriter
 }
 
 type NullSerialCable struct{}

--- a/devices/serial_port.go
+++ b/devices/serial_port.go
@@ -86,6 +86,7 @@ type SerialPort struct {
 func NewSerialPort() *SerialPort {
 	return &SerialPort{
 		cable: &NullSerialCable{},
+		recv:  0xFF,
 	}
 }
 

--- a/devices/serial_port.go
+++ b/devices/serial_port.go
@@ -103,9 +103,21 @@ func (sp *SerialPort) Step(cycles uint8, ic *InterruptController) {
 		} else {
 			sp.clk -= uint(cycles)
 		}
+
+		return
 	}
 
-	// TODO: Implement external clock
+	// External clock: poll for a byte driven by the external sender
+	recvVal, err := sp.cable.ReadByte()
+	if err != nil {
+		// Assume byte isn't ready
+		return
+	}
+
+	_ = sp.cable.WriteByte(sp.buf)
+	sp.buf = recvVal
+	sp.ctrl.SetTransferEnabled(false)
+	ic.RequestSerial()
 }
 
 func (sp *SerialPort) OnRead(mmu *mem.MMU, addr uint16) mem.MemRead {

--- a/devices/serial_port.go
+++ b/devices/serial_port.go
@@ -28,15 +28,15 @@ func (sc *SerialCtrl) Read() byte {
 	value := byte(0x0)
 
 	if sc.transferEnabled {
-		value &= SC_TRANSFER_EN
+		value |= SC_TRANSFER_EN
 	}
 
 	if sc.clockSpeedDbl {
-		value &= SC_CLK_SPD
+		value |= SC_CLK_SPD
 	}
 
 	if sc.clockInternal {
-		value &= SC_CLK_INT
+		value |= SC_CLK_INT
 	}
 
 	return value

--- a/devices/serial_port.go
+++ b/devices/serial_port.go
@@ -16,6 +16,9 @@ const (
 
 	SC_CLK_EXT = 0x0
 	SC_CLK_INT = 0x1
+
+	SERIAL_PORT_CLK_NORMAL = 4096 // 512 cycles * 8 bits
+	SERIAL_PORT_CLK_FAST   = 128  // 16 cycles * 8 bits
 )
 
 type SerialCtrl struct {
@@ -141,8 +144,11 @@ func (sp *SerialPort) OnWrite(mmu *mem.MMU, addr uint16, value byte) mem.MemWrit
 		sp.ctrl.Write(value)
 
 		if sp.ctrl.IsTransferEnabled() && sp.ctrl.IsClockInternal() {
-			// TODO(GBC): derive this somehow and factor in GBC speeds when relevant
-			sp.clk = 8192
+			if sp.ctrl.IsClockSpeedDbl() {
+				sp.clk = SERIAL_PORT_CLK_FAST
+			} else {
+				sp.clk = SERIAL_PORT_CLK_NORMAL
+			}
 
 			_ = sp.cable.WriteByte(sp.buf)
 


### PR DESCRIPTION
This PR adds support for using host I/O for the serial port, outside of just stdout & stderr for output.

This is pretty niche, but been finding it useful for iterating on my [gbtty](https://github.com/maxfierke/gbtty/blob/main/gb) Game Boy ROM without having to move things over to my flashcart constantly.

Currently:

- Unix domain socket - This makes it really easy to communicate from a Game Boy ROM with a program on your computer, provided the two are speaking the same language in terms of handshake, bits & bytes, etc. Your program can simply open socket and speak direct with the ROM on the Game Boy.

Not yet supported, but could be interesting:
- Serial TTY (for USB-to-link adapters)
- Named pipes (more niche, need separate RX/TX pipes, but they work w/ file I/O)