### PR TITLE
Add profiling options and reduce some allocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ bin/
 # Logfiles
 *.log
 
+# Profiles
+*.prof
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
+	"runtime/pprof"
 	"strings"
 
 	"github.com/maxfierke/gogo-gb/cart"
@@ -23,8 +25,10 @@ type RunCmdOptions struct {
 	bootRomPath  string
 	cartPath     string
 	cartSavePath string
+	cpuProfile   string
 	debugger     string
 	headless     bool
+	memProfile   string
 	model        string
 	serialPort   string
 	skipBootRom  bool
@@ -67,6 +71,9 @@ func init() {
 
 	runCmd.Flags().StringVarP(&runCmdOptions.cartSavePath, "save", "s", "", "Path to cartridge save file (.sav). Defaults to a .sav file with the same name as the cartridge file")
 	_ = runCmd.MarkFlagFilename("save", ".sav")
+
+	runCmd.Flags().StringVar(&runCmdOptions.cpuProfile, "cpuprofile", "", "Start cpu profile and output to named file")
+	runCmd.Flags().StringVar(&runCmdOptions.memProfile, "memprofile", "", "Start mem profile and output to named file")
 
 	runCmd.Flags().StringVarP(&runCmdOptions.debugger, "debugger", "d", "", "Specify debugger to use (\"gameboy-doctor\", \"interactive\")")
 	runCmd.Flags().StringVarP(&runCmdOptions.model, "model", "m", "auto", "Specify model to use (\"auto\", \"dmg\", \"cgb\")")
@@ -363,6 +370,33 @@ func runCart(ctx context.Context, logger *log.Logger, options *RunCmdOptions) er
 			err := saveCart(cartridge, logger, options)
 			if err != nil {
 				logger.Printf("WARN: Error occurred while saving: %s", err.Error())
+			}
+		}()
+	}
+
+	if options.cpuProfile != "" {
+		f, err := os.Create(options.cpuProfile)
+		if err != nil {
+			log.Fatal("could not create CPU profile: ", err)
+		}
+		defer f.Close()
+		if err := pprof.StartCPUProfile(f); err != nil {
+			log.Fatal("could not start CPU profile: ", err)
+		}
+		defer pprof.StopCPUProfile()
+	}
+
+	if options.memProfile != "" {
+		defer func() {
+			f, err := os.Create(options.memProfile)
+			if err != nil {
+				log.Fatal("could not create memory profile: ", err)
+			}
+			defer f.Close()
+			runtime.GC()
+
+			if err := pprof.Lookup("allocs").WriteTo(f, 0); err != nil {
+				log.Fatal("could not write memory profile: ", err)
 			}
 		}()
 	}

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -137,7 +137,7 @@ func (cpu *CPU) Step(mmu *mem.MMU) (uint8, error) {
 	return cycles, err
 }
 
-func (cpu *CPU) FetchAndDecode(mmu *mem.MMU, addr uint16) (*isa.Instruction, error) {
+func (cpu *CPU) FetchAndDecode(mmu *mem.MMU, addr uint16) (isa.Instruction, error) {
 	// Fetch :)
 	opcodeByte := mmu.Read8(addr)
 	prefixed := opcodeByte == 0xCB
@@ -152,16 +152,16 @@ func (cpu *CPU) FetchAndDecode(mmu *mem.MMU, addr uint16) (*isa.Instruction, err
 
 	if !exist {
 		if prefixed {
-			return nil, fmt.Errorf("unimplemented instruction found @ 0x%04X: 0xCB%02X", addr, opcodeByte)
+			return isa.Instruction{}, fmt.Errorf("unimplemented instruction found @ 0x%04X: 0xCB%02X", addr, opcodeByte)
 		} else {
-			return nil, fmt.Errorf("unimplemented instruction found @ 0x%04X: 0x%02X", addr, opcodeByte)
+			return isa.Instruction{}, fmt.Errorf("unimplemented instruction found @ 0x%04X: 0x%02X", addr, opcodeByte)
 		}
 	}
 
 	return inst, nil
 }
 
-func (cpu *CPU) Execute(mmu *mem.MMU, inst *isa.Instruction) (nextPC uint16, cycles uint8, err error) {
+func (cpu *CPU) Execute(mmu *mem.MMU, inst isa.Instruction) (nextPC uint16, cycles uint8, err error) {
 	opcode := inst.Opcode
 
 	if opcode.CbPrefixed {

--- a/cpu/isa/instruction.go
+++ b/cpu/isa/instruction.go
@@ -7,6 +7,6 @@ type Instruction struct {
 	Opcode *Opcode
 }
 
-func (ins *Instruction) String() string {
+func (ins Instruction) String() string {
 	return fmt.Sprintf("0x%04X    %s", ins.Addr, ins.Opcode)
 }

--- a/cpu/isa/opcodes.go
+++ b/cpu/isa/opcodes.go
@@ -79,7 +79,7 @@ type Opcodes struct {
 	CbPrefixed map[uint8]*Opcode
 }
 
-func (opcodes *Opcodes) InstructionFromByte(addr uint16, value byte, prefixed bool) (*Instruction, bool) {
+func (opcodes *Opcodes) InstructionFromByte(addr uint16, value byte, prefixed bool) (Instruction, bool) {
 	var opcode *Opcode
 	var present bool
 
@@ -90,10 +90,10 @@ func (opcodes *Opcodes) InstructionFromByte(addr uint16, value byte, prefixed bo
 	}
 
 	if !present {
-		return nil, present
+		return Instruction{}, present
 	}
 
-	return &Instruction{
+	return Instruction{
 		Addr:   addr,
 		Opcode: opcode,
 	}, true

--- a/ppu/palettes.go
+++ b/ppu/palettes.go
@@ -64,6 +64,10 @@ func NewRGB555(r, g, b uint8) rgb555 {
 }
 
 func (c rgb555) RGBA() (r, g, b, a uint32) {
+	return c.colorRGBA().RGBA()
+}
+
+func (c rgb555) colorRGBA() color.RGBA {
 	color := color.RGBA{
 		R: c.R << 3,
 		G: c.G << 3,
@@ -74,7 +78,7 @@ func (c rgb555) RGBA() (r, g, b, a uint32) {
 	color.G |= color.G >> 2
 	color.B |= color.B >> 2
 
-	return color.RGBA()
+	return color
 }
 
 const (

--- a/ppu/ppu.go
+++ b/ppu/ppu.go
@@ -155,11 +155,11 @@ func NewPPU(ic InterruptRequester, oam *OAM, vram *VRAM, renderer RendererConstr
 	return ppu
 }
 
-var grayScales = []color.Color{
-	color.White,
-	color.GrayModel.Convert(color.RGBA{R: 170, G: 170, B: 170}),
-	color.GrayModel.Convert(color.RGBA{R: 85, G: 85, B: 85}),
-	color.Black,
+var grayScales = []color.RGBA{
+	{R: 255, G: 255, B: 255, A: 255},
+	{R: 170, G: 170, B: 170, A: 255},
+	{R: 85, G: 85, B: 85, A: 255},
+	{A: 255},
 }
 
 func (ppu *PPU) Draw() image.Image {
@@ -195,17 +195,17 @@ func (ppu *PPU) ObjectSize() objectSize {
 	return ppu.lcdCtrl.objectSize
 }
 
-func (ppu *PPU) GetBGPaletteColor(colorID ColorID, cgbPaletteID uint8) color.Color {
+func (ppu *PPU) GetBGPaletteColor(colorID ColorID, cgbPaletteID uint8) color.RGBA {
 	if ppu.IsColorEnabled() {
-		return ppu.cgbBGPalettes.palettes[cgbPaletteID][colorID]
+		return ppu.cgbBGPalettes.palettes[cgbPaletteID][colorID].colorRGBA()
 	}
 
 	return grayScales[ppu.bgPalette[colorID]]
 }
 
-func (ppu *PPU) GetObjPaletteColor(colorID ColorID, objAttributes ObjectAttributes) color.Color {
+func (ppu *PPU) GetObjPaletteColor(colorID ColorID, objAttributes ObjectAttributes) color.RGBA {
 	if ppu.IsColorEnabled() {
-		return ppu.cgbObjPalettes.palettes[objAttributes.CGBPaletteID][colorID]
+		return ppu.cgbObjPalettes.palettes[objAttributes.CGBPaletteID][colorID].colorRGBA()
 	}
 
 	return grayScales[ppu.objPalettes[objAttributes.DMGPaletteID][colorID]]

--- a/ppu/rendering/scanline.go
+++ b/ppu/rendering/scanline.go
@@ -23,7 +23,7 @@ const (
 type RenderedPixel struct {
 	Layer   PixelLayer
 	ColorID ppu.ColorID
-	Color   color.Color
+	Color   color.RGBA
 }
 
 type PixelLayer uint8
@@ -40,32 +40,28 @@ type ScanlineRenderer struct {
 	vram *ppu.VRAM
 
 	framebuf [FB_HEIGHT][FB_WIDTH]RenderedPixel
+	fbImage  *image.RGBA
 }
 
 var _ ppu.Renderer = (*ScanlineRenderer)(nil)
 
 func Scanline(ppu *ppu.PPU, oam *ppu.OAM, vram *ppu.VRAM) ppu.Renderer {
 	return &ScanlineRenderer{
-		ppu:  ppu,
-		oam:  oam,
-		vram: vram,
+		fbImage: image.NewRGBA(image.Rect(0, 0, FB_WIDTH, FB_HEIGHT)),
+		ppu:     ppu,
+		oam:     oam,
+		vram:    vram,
 	}
 }
 
 func (r *ScanlineRenderer) DrawImage() image.Image {
-	fbImage := image.NewRGBA(
-		image.Rect(0, 0, FB_WIDTH, FB_HEIGHT),
-	)
-
 	for y := range FB_HEIGHT {
 		for x, pixel := range r.framebuf[y] {
-			if pixel.Color != nil {
-				fbImage.Set(x, y, pixel.Color)
-			}
+			r.fbImage.SetRGBA(x, y, pixel.Color)
 		}
 	}
 
-	return fbImage
+	return r.fbImage
 }
 
 func (r *ScanlineRenderer) Step(cycles uint8) uint8 {
@@ -334,7 +330,7 @@ func (r *ScanlineRenderer) readPixel(x, y uint8) RenderedPixel {
 	return r.framebuf[y][x]
 }
 
-func (r *ScanlineRenderer) writePixel(x, y uint8, colorID ppu.ColorID, color color.Color, layer PixelLayer) {
+func (r *ScanlineRenderer) writePixel(x, y uint8, colorID ppu.ColorID, color color.RGBA, layer PixelLayer) {
 	r.framebuf[y][x].Color = color
 	r.framebuf[y][x].ColorID = colorID
 	r.framebuf[y][x].Layer = layer


### PR DESCRIPTION
This PR integrates `runtime/pprof` and adds a few new flags for optionally enabling CPU or memory allocation profiling.

Fixed a few bits of low-hanging fruit on the allocation side.